### PR TITLE
Support :auto of source attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ reversible_cryptography encrypt --password=PASSWORD --src-file=/path/to/secret_f
 ### Recipe
 
 ```ruby
+require "itamae-plugin-resource-encrypted_remote_file"
+
 encrypted_remote_file "/home/deployer/.ssh/id_rsa" do
   owner    "root"
   group    "root"

--- a/lib/itamae/plugin/resource/encrypted_remote_file.rb
+++ b/lib/itamae/plugin/resource/encrypted_remote_file.rb
@@ -10,11 +10,10 @@ module Itamae
         define_attribute :password, type: String
 
         def pre_action
-          src_expanded_path = ::File.expand_path(attributes.source, ::File.dirname(@recipe.path))
-          encrypted_data = File.read(src_expanded_path).strip
+          encrypted_data = File.read(source_file).strip
 
           decrypted_data = ReversibleCryptography::Message.decrypt(encrypted_data, attributes.password)
-          @decrypted_tempfile = Tempfile.open(File.basename(attributes.source)) do |f|
+          @decrypted_tempfile = Tempfile.open(File.basename(source_file)) do |f|
             f.write(decrypted_data)
             f
           end


### PR DESCRIPTION
Use [`Itamae::Resource::RemoteFile#source_file`](https://github.com/itamae-kitchen/itamae/blob/master/lib/itamae/resource/remote_file.rb#L16-L18) to support [`source :auto`](https://github.com/itamae-kitchen/itamae/wiki/remote_file-resource#attributes).
And tiny update readme :wink: 
## Example

```
encrypted_remote_file "/home/deployer/.ssh/id_rsa" do
  owner    "root"
  group    "root"
  password ENV["ID_RSA_PASSWORD"]
end
```
