### PR TITLE
Update CI image

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,7 +26,7 @@ Vagrant.configure(2) do |config|
   config.vm.define :centos70 do |c|
     c.vm.box = "centos/7"
     c.vm.provider :digital_ocean do |provider, override|
-      provider.image = "centos-7-0-x64"
+      provider.image = "centos-7-x64"
     end
     c.vm.hostname  = 'itamae-encryptedremotefile-centos70'
     c.vm.hostname  += "-#{ENV['WERCKER_RUN_ID']}" if ENV['WERCKER_RUN_ID']


### PR DESCRIPTION
https://app.wercker.com/sue445/itamae-plugin-resource-encrypted_remote_file/runs/build-centos70/59d3b50a8e888f0001b27cb7?step=59d3b585af52880001e9c915

```
+ vagrant up centos70 --provider=digital_ocean
Bringing machine 'centos70' up with 'digital_ocean' provider...
==> centos70: Using existing SSH key: wercker-itamae-plugin-resource-encrypted_remote_file
There was an issue with the request made to the DigitalOcean
API at:

Path: /v2/droplets
URI Params: {:size=>"512MB", :region=>"nyc3", :image=>"centos-7-0-x64", :name=>"itamae-encryptedremotefile-centos70-59d3b50a8e888f0001b27cb7", :ssh_keys=>[1780862], :private_networking=>false, :ipv6=>false}

The response status from the API was:

Status: 422
Response: {"id"=>"unprocessable_entity", "message"=>"You specified an invalid image for Droplet creation."}
```